### PR TITLE
Some enhancement proposed

### DIFF
--- a/formulaview.cpp
+++ b/formulaview.cpp
@@ -10,7 +10,9 @@ FormulaView::FormulaView( QWidget *parent ):
     d_fontSize( 8 ),
     d_transformation( true ),
     d_scale( false ),
-    d_rotation( 0 )
+    d_rotation( 0 ),
+    d_drawFrames( false ),
+    d_colors( false )
 {
 }
 

--- a/formulaview.cpp
+++ b/formulaview.cpp
@@ -41,6 +41,29 @@ void FormulaView::setFormula( const QString &formula )
     update();
 }
 
+void FormulaView::loadFormula(const QString& fileName)
+{
+    QFile file( fileName );
+    if (!file.exists())
+    {
+        d_mmlDoc->clear();
+        return;
+    }
+    if ( !file.open(QIODevice::ReadOnly | QIODevice::Text) )
+    {
+        qWarning() << "Error while opening formula file" << fileName
+                   << "with message" << file.errorString();
+        d_mmlDoc->clear();
+        return;
+    }
+    setFormula( file.readAll() );
+}
+
+void FormulaView::clearFormula()
+{
+    d_mmlDoc->clear();
+}
+
 void FormulaView::setFontSize( const qreal &fontSize )
 {
     d_mmlDoc->setBaseFontPointSize( fontSize );

--- a/formulaview.cpp
+++ b/formulaview.cpp
@@ -90,13 +90,20 @@ void FormulaView::renderFormula( QPainter *painter ) const
     doc.setDrawFrames( d_drawFrames );
 #endif
 
+    QRect viewRect = rect();
     QRectF docRect;
     docRect.setSize( doc.size() );
-    docRect.moveCenter( rect().center() );
+    docRect.moveCenter( viewRect.center() );
 
     if ( d_transformation )
     {
-        const double scaleF = d_scale ? 2.0 : 1.0;
+        double scaleF = 1;
+        if ( d_scale )
+        {
+            const double scaleX = viewRect.width() / docRect.width();
+            const double scaleY = viewRect.height() / docRect.height();
+            scaleF = qMin(scaleX, scaleY);
+         }
 
         painter->save();
 

--- a/formulaview.cpp
+++ b/formulaview.cpp
@@ -6,7 +6,7 @@
 #include <qpainter.h>
 
 FormulaView::FormulaView( QWidget *parent ):
-    QWidget( parent ),
+    QFrame( parent ),
     d_transformation( true ),
     d_scale( false ),
     d_rotation( 0 )
@@ -90,19 +90,39 @@ void FormulaView::setColors( const bool &colors )
     update();
 }
 
+void FormulaView::setPaddings( const QMargins &value )
+{
+    d_paddings = value;
+}
+
+void FormulaView::setPaddings( const int &value )
+{
+    d_paddings.setLeft(value);
+    d_paddings.setTop(value);
+    d_paddings.setRight(value);
+    d_paddings.setBottom(value);
+}
+
 void FormulaView::paintEvent( QPaintEvent *event )
 {
+    QFrame::paintEvent(event);
+
     QPainter painter( this );
     painter.setClipRegion( event->region() );
 
-    painter.fillRect( event->rect(), Qt::white );
+    int fw = frameWidth();
+    QRect viewRect = event->rect().adjusted(fw, fw, -fw, -fw);
 
-    renderFormula( &painter );
+    painter.fillRect( viewRect, d_mmlDoc->backgroundColor() );
+
+    if ( !d_paddings.isNull() )
+        viewRect = viewRect.marginsRemoved(d_paddings);
+
+    renderFormula( &painter, viewRect );
 }
 
-void FormulaView::renderFormula( QPainter *painter ) const
+void FormulaView::renderFormula( QPainter *painter, const QRect &viewRect ) const
 {
-    QRect viewRect = rect();
     QRectF docRect;
     docRect.setSize( d_mmlDoc->size() );
     docRect.moveCenter( viewRect.center() );

--- a/formulaview.h
+++ b/formulaview.h
@@ -17,6 +17,9 @@ public:
 
     QString formula() const;
 
+    void loadFormula(const QString& fileName);
+    void clearFormula();
+
     void setPaddings( const QMargins &value );
     void setPaddings( const int &value );
 

--- a/formulaview.h
+++ b/formulaview.h
@@ -5,12 +5,15 @@
 
 class QPainter;
 
+class QwtMathMLDocument;
+
 class FormulaView: public QWidget
 {
     Q_OBJECT
 
 public:
     FormulaView( QWidget *parent = NULL );
+    ~FormulaView();
 
     QString formula() const;
 
@@ -30,13 +33,11 @@ private:
     void renderFormula( QPainter * ) const;
 
 private:
+    QwtMathMLDocument* d_mmlDoc;
     QString d_formula;
-    qreal d_fontSize;
     bool d_transformation;
     bool d_scale;
     qreal d_rotation;
-    bool d_drawFrames;
-    bool d_colors;
 };
 
 #endif

--- a/formulaview.h
+++ b/formulaview.h
@@ -1,13 +1,13 @@
 #ifndef _FORMULA_VIEW_H_
 #define _FORMULA_VIEW_H_
 
-#include <qwidget.h>
+#include <qframe.h>
 
 class QPainter;
 
 class QwtMathMLDocument;
 
-class FormulaView: public QWidget
+class FormulaView: public QFrame
 {
     Q_OBJECT
 
@@ -16,6 +16,9 @@ public:
     ~FormulaView();
 
     QString formula() const;
+
+    void setPaddings( const QMargins &value );
+    void setPaddings( const int &value );
 
 public Q_SLOTS:
     void setFormula( const QString & );
@@ -30,9 +33,10 @@ protected:
     virtual void paintEvent( QPaintEvent * );
 
 private:
-    void renderFormula( QPainter * ) const;
+    void renderFormula( QPainter *, const QRect & ) const;
 
 private:
+    QMargins d_paddings;
     QwtMathMLDocument* d_mmlDoc;
     QString d_formula;
     bool d_transformation;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1,8 +1,6 @@
 #include "formulaview.h"
 #include "mainwindow.h"
 
-#include <qapplication.h>
-#include <qbuffer.h>
 #include <qcheckbox.h>
 #include <qcombobox.h>
 #include <qdebug.h>
@@ -13,7 +11,7 @@
 #include <qtoolbar.h>
 #include <qtoolbutton.h>
 
-MainWindow::MainWindow()
+MainWindow::MainWindow() : QMainWindow()
 {
     d_view = new FormulaView( this );
     setCentralWidget( d_view );
@@ -136,14 +134,7 @@ void MainWindow::loadFormula( const QString &fileName )
 {
     statusBar()->showMessage( fileName );
 
-    QFile file( fileName );
-    if ( !file.open(QIODevice::ReadOnly | QIODevice::Text) )
-        return;
-
-    const QByteArray document = file.readAll();
-    file.close();
-
-    d_view->setFormula( document );
+    d_view->loadFormula( fileName );
 }
 
 void MainWindow::updateFontSize( const QString &fontSize )

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -7,6 +7,7 @@
 #include <qcombobox.h>
 #include <qdebug.h>
 #include <qfiledialog.h>
+#include <qlabel.h>
 #include <qmimedata.h>
 #include <qstatusbar.h>
 #include <qtoolbar.h>
@@ -25,6 +26,10 @@ MainWindow::MainWindow()
     btnLoad->setToolButtonStyle( Qt::ToolButtonTextUnderIcon );
     toolBar->addWidget( btnLoad );
 
+    toolBar->addSeparator();
+
+    toolBar->addWidget( new QLabel( "Font size" ) );
+
     QComboBox *comboFontSizes = new QComboBox( toolBar );
     QStringList fontSizes;
     for ( int i = 8; i <= 128; i += 2 )
@@ -33,14 +38,18 @@ MainWindow::MainWindow()
     comboFontSizes->setCurrentIndex( 32 );
     toolBar->addWidget( comboFontSizes );
 
+    toolBar->addSeparator();
+
     QCheckBox *checkTransformation = new QCheckBox( toolBar );
-    checkTransformation->setText( "Transformation" );
+    checkTransformation->setText( "Transformations" );
     checkTransformation->setChecked( true );
     toolBar->addWidget( checkTransformation );
 
     d_checkScale = new QCheckBox( toolBar );
-    d_checkScale->setText( "Scale" );
+    d_checkScale->setText( "Fit to window" );
     toolBar->addWidget( d_checkScale );
+
+    toolBar->addWidget( new QLabel( "Rotation" ) );
 
     d_comboRotations = new QComboBox( toolBar );
     QStringList rotations;
@@ -49,6 +58,8 @@ MainWindow::MainWindow()
     d_comboRotations->addItems( rotations );
     d_comboRotations->setCurrentIndex( 0 );
     toolBar->addWidget( d_comboRotations );
+
+    toolBar->addSeparator();
 
     QCheckBox *checkDrawFrames = new QCheckBox( toolBar );
     checkDrawFrames->setText( "Draw frames" );

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -61,9 +61,11 @@ MainWindow::MainWindow()
 
     toolBar->addSeparator();
 
+#ifdef MML_TEST
     QCheckBox *checkDrawFrames = new QCheckBox( toolBar );
     checkDrawFrames->setText( "Draw frames" );
     toolBar->addWidget( checkDrawFrames );
+#endif
 
     QCheckBox *checkColors = new QCheckBox( toolBar );
     checkColors->setText( "Colors" );
@@ -76,18 +78,22 @@ MainWindow::MainWindow()
     connect( checkTransformation, SIGNAL( toggled( bool ) ), this, SLOT( updateTransformation( const bool & ) ) );
     connect( d_checkScale, SIGNAL( toggled( bool ) ), this, SLOT( updateScaling( const bool & ) ) );
     connect( d_comboRotations, SIGNAL( currentIndexChanged( const QString & ) ), this, SLOT( updateRotation( const QString & ) ) );
+#ifdef MML_TEST
     connect( checkDrawFrames, SIGNAL( toggled( bool ) ), this, SLOT( updateDrawFrames( const bool & ) ) );
+#endif
     connect( checkColors, SIGNAL( toggled( bool ) ), this, SLOT( updateColors( const bool & ) ) );
 
     updateFontSize( comboFontSizes->currentText() );
     updateTransformation( checkTransformation->isChecked() );
     updateScaling( d_checkScale->isChecked() );
     updateRotation( d_comboRotations->currentText() );
+#ifdef MML_TEST
     updateDrawFrames( checkDrawFrames->isChecked() );
+#endif
     updateColors( checkColors->isChecked() );
 
     setAcceptDrops(true);
-};
+}
 
 void MainWindow::dragEnterEvent(QDragEnterEvent *event)
 {

--- a/qwt-mml.pro
+++ b/qwt-mml.pro
@@ -12,6 +12,7 @@ MOC_DIR      = moc
 OBJECTS_DIR  = obj
 
 # DEFINES += MML_TEST
+DEFINES += NO_QWT
 
 HEADERS = \
 	qwt_mml_document.h \

--- a/qwt_mml_document.cpp
+++ b/qwt_mml_document.cpp
@@ -708,6 +708,11 @@ static const QwtMmlNodeSpec g_node_spec_data[] =
     { QwtMml::NoNode,         0,            0,                0,                            0,                       0                                                                     }
 };
 
+static const QSet<QString> g_ignored_tag_names =
+{
+    "annotation" // LibreOffice stores StarMath expression in this tag
+};
+
 static const char *g_oper_spec_names[g_oper_spec_rows] =
 {
     "accent", "fence", "largeop", "lspace", "minsize", "movablelimits",
@@ -3773,6 +3778,8 @@ static const QwtMmlNodeSpec *mmlFindNodeSpec( const QString &tag )
     {
         if ( tag == spec->tag ) return spec;
     }
+    if (g_ignored_tag_names.contains(tag))
+        return spec; // QwtMml::NoNode
     return 0;
 }
 

--- a/qwt_mml_document.h
+++ b/qwt_mml_document.h
@@ -1,7 +1,12 @@
 #ifndef _QWT_MML_DOCUMENT_H_
 #define _QWT_MML_DOCUMENT_H_
 
+#ifdef NO_QWT
+#define QWT_EXPORT
+#else
 #include <qwt_global.h>
+#endif
+
 
 #include <qcolor.h>
 #include <qstring.h>

--- a/qwt_mml_entity_table.h
+++ b/qwt_mml_entity_table.h
@@ -1,7 +1,11 @@
 #ifndef _QWT_MML_ENTITY_TABLE_H_
 #define _QWT_MML_ENTITY_TABLE_H_
 
+#ifdef NO_QWT
+#define QWT_EXPORT
+#else
 #include <qwt_global.h>
+#endif
 
 #include <qstring.h>
 


### PR DESCRIPTION
I'd like to propose some enhancement in this cool classes:

1. Ability to silently skip some tags in mm files. When I've tried to make mml in Libre Office Math I've noticed that it stores original formula text in the tag ```annotation```, so it should not be rendered.  Currently only this tag is skipped.

2. Because it is possible to use these classes separately from ```qwt```, including of ```qwt_global.h``` should be optional. I've made it by definition of ```NO_QWT``` that one can define in his own .pro file along with including these sources into project.

3.  ```FormulaView``` widget is a good for using it as independent widget, not only for test purposes. So I've tried to slightly optimize it to parse formula only once when it's set but not for each repainting. Also original scaling by factor 2 is not seems very useful, so I took him a meaning of 'fit to widget'. When one set ```setScale(true)```, formula begins to render on all available widget space excluding some customizable paddings.

4. By means of using ```FormulaView``` as ready formula displaying widget, it's good for it to have frame. So I've rebased it to ```QFrame```.

5. Toolbar in main window of test project is slightly adjusted: labels and separators added.